### PR TITLE
Add books.ts with book-related AI functions

### DIFF
--- a/src/content/books.ts
+++ b/src/content/books.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { createAIFunction } from '../src/factory'
+import { createAIFunction } from '../factory'
 
 // Create the writeBook function with proper schema
 const writeBook = createAIFunction(

--- a/src/content/books.ts
+++ b/src/content/books.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod'
+import { createAIFunction } from '../src/factory'
+
+// Create the writeBook function with proper schema
+const writeBook = createAIFunction(
+  z.object({
+    title: z.string().describe('title of the book'),
+    author: z.string().describe('name of the author'),
+    genre: z.string().describe('genre of the book'),
+    audience: z.string().describe('target audience for the book'),
+    content: z.string().describe('complete book content'),
+  }),
+)
+
+// Create the developProposal function with proper schema
+const developProposal = createAIFunction(
+  z.object({
+    title: z.string().describe('proposed title of the book'),
+    genre: z.string().describe('genre of the book'),
+    audience: z.string().describe('target audience for the book'),
+    concept: z.string().describe('high-level concept of the book'),
+    marketAnalysis: z.string().describe('analysis of the target market'),
+    competitiveAnalysis: z.string().describe('analysis of competing books'),
+    uniqueSellingPoints: z.array(z.string()).describe('unique selling points of the book'),
+    outline: z.string().describe('brief outline of the book'),
+  }),
+)
+
+// Create the draftTableOfContents function with proper schema
+const draftTableOfContents = createAIFunction(
+  z.object({
+    title: z.string().describe('title of the book'),
+    genre: z.string().describe('genre of the book'),
+    chapters: z
+      .array(
+        z.object({
+          title: z.string().describe('title of the chapter'),
+          summary: z.string().describe('brief summary of the chapter content'),
+        }),
+      )
+      .describe('list of chapters with titles and summaries'),
+    frontMatter: z.array(z.string()).describe('front matter sections like preface, introduction, etc.'),
+    backMatter: z.array(z.string()).describe('back matter sections like appendices, glossary, etc.'),
+  }),
+)
+
+// Create the outlineChapter function with proper schema
+const outlineChapter = createAIFunction(
+  z.object({
+    chapterTitle: z.string().describe('title of the chapter'),
+    chapterNumber: z.number().describe('number of the chapter in the book'),
+    keyPoints: z.array(z.string()).describe('key points to cover in the chapter'),
+    scenes: z
+      .array(
+        z.object({
+          title: z.string().describe('title or brief description of the scene'),
+          summary: z.string().describe('summary of what happens in the scene'),
+          characters: z.array(z.string()).optional().describe('characters involved in the scene'),
+        }),
+      )
+      .optional()
+      .describe('scenes within the chapter (for fiction)'),
+    sections: z
+      .array(
+        z.object({
+          heading: z.string().describe('section heading'),
+          content: z.string().describe('brief description of section content'),
+        }),
+      )
+      .optional()
+      .describe('sections within the chapter (for non-fiction)'),
+  }),
+)
+
+// Create the writeSection function with proper schema
+const writeSection = createAIFunction(
+  z.object({
+    sectionTitle: z.string().describe('title of the section'),
+    chapterTitle: z.string().describe('title of the parent chapter'),
+    keyPoints: z.array(z.string()).describe('key points to cover in the section'),
+    tone: z.string().describe('tone of the writing (formal, conversational, etc.)'),
+    content: z.string().describe('complete section content'),
+  }),
+)
+
+// Create the reviewChapter function with proper schema
+const reviewChapter = createAIFunction(
+  z.object({
+    chapterTitle: z.string().describe('title of the chapter'),
+    content: z.string().describe('content of the chapter'),
+    feedback: z.string().describe('detailed feedback on the chapter'),
+    strengthPoints: z.array(z.string()).describe('strengths of the chapter'),
+    improvementPoints: z.array(z.string()).describe('areas for improvement'),
+    consistencyIssues: z.array(z.string()).optional().describe('consistency issues with other parts of the book'),
+  }),
+)
+
+// Create the editChapter function with proper schema
+const editChapter = createAIFunction(
+  z.object({
+    chapterTitle: z.string().describe('title of the chapter'),
+    originalContent: z.string().describe('original content of the chapter'),
+    editedContent: z.string().describe('edited content of the chapter'),
+    changes: z.array(z.string()).describe('list of changes made'),
+    rationale: z.string().describe('rationale for the changes'),
+  }),
+)
+
+// Create the reviewBook function with proper schema
+const reviewBook = createAIFunction(
+  z.object({
+    title: z.string().describe('title of the book'),
+    content: z.string().describe('content of the book or summary of content'),
+    overallFeedback: z.string().describe('overall feedback on the book'),
+    strengthPoints: z.array(z.string()).describe('strengths of the book'),
+    improvementPoints: z.array(z.string()).describe('areas for improvement'),
+    marketFit: z.string().describe('assessment of how well the book fits its target market'),
+    recommendations: z.array(z.string()).describe('recommendations for improvement'),
+  }),
+)
+
+// Create the editBook function with proper schema
+const editBook = createAIFunction(
+  z.object({
+    title: z.string().describe('title of the book'),
+    originalContent: z.string().describe('original content or summary of the book'),
+    editedContent: z.string().describe('edited content or summary of changes'),
+    majorChanges: z.array(z.string()).describe('list of major changes made'),
+    minorChanges: z.array(z.string()).describe('list of minor changes made'),
+    rationale: z.string().describe('rationale for the changes'),
+  }),
+)
+
+// Create the publishBook function with proper schema
+const publishBook = createAIFunction(
+  z.object({
+    title: z.string().describe('title of the book'),
+    author: z.string().describe('name of the author'),
+    finalContent: z.string().describe('final content or confirmation of completion'),
+    publishingPlatforms: z.array(z.string()).describe('platforms where the book will be published'),
+    marketingPlan: z.string().describe('plan for marketing the book'),
+    launchDate: z.string().describe('planned launch date'),
+    pricingStrategy: z.string().describe('pricing strategy for the book'),
+    distributionChannels: z.array(z.string()).describe('channels for book distribution'),
+  }),
+)
+
+// Export the functions
+export { writeBook, developProposal, draftTableOfContents, outlineChapter, writeSection, reviewChapter, editChapter, reviewBook, editBook, publishBook }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,19 @@ import { createAIFunction, createTemplateFunction } from './factory'
 import { createListFunction } from './factory/list'
 import { AI, ListFunction, BaseTemplateFunction, AIFunctionOptions, TemplateResult } from './types'
 import { z } from 'zod'
+// Import book-related functions
+import {
+  writeBook,
+  developProposal,
+  draftTableOfContents,
+  outlineChapter,
+  writeSection,
+  reviewChapter,
+  editChapter,
+  reviewBook,
+  editBook,
+  publishBook,
+} from './content/books'
 
 // Create the main template function with async iteration support
 const templateFn = createTemplateFunction()
@@ -58,7 +71,19 @@ function createWrappedTemplateFunction(baseFn: BaseTemplateFunction): BaseTempla
 }
 
 const aiFn = createWrappedTemplateFunction(templateFn)
-export const ai = Object.assign(aiFn, { categorizeProduct }) as unknown as AI
+export const ai = Object.assign(aiFn, {
+  categorizeProduct,
+  writeBook,
+  developProposal,
+  draftTableOfContents,
+  outlineChapter,
+  writeSection,
+  reviewChapter,
+  editChapter,
+  reviewBook,
+  editBook,
+  publishBook,
+}) as unknown as AI
 
 // Create the list function with template literal and async iteration support
 export const list = createWrappedTemplateFunction(listFn) as ListFunction

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,48 +7,48 @@ export type Queue = Omit<PQueue, 'add'> & {
 }
 
 export interface RetryOptions {
-  maxRetries: number;
-  initialDelay: number;
-  maxDelay: number;
-  backoffFactor: number;
+  maxRetries: number
+  initialDelay: number
+  maxDelay: number
+  backoffFactor: number
 }
 
 export interface RateLimitOptions {
-  requestsPerMinute: number;
-  burstLimit?: number;
-  timeoutMs?: number;
+  requestsPerMinute: number
+  burstLimit?: number
+  timeoutMs?: number
 }
 
 export interface RequestHandlingOptions {
-  retry?: RetryOptions;
-  rateLimit?: RateLimitOptions;
-  timeout?: number;
-  maxRetries?: number;
-  retryDelay?: number;
-  streamingTimeout?: number;
-  concurrency?: number;
+  retry?: RetryOptions
+  rateLimit?: RateLimitOptions
+  timeout?: number
+  maxRetries?: number
+  retryDelay?: number
+  streamingTimeout?: number
+  concurrency?: number
   requestHandling?: {
-    retry?: RetryOptions;
-    rateLimit?: RateLimitOptions;
-    timeout?: number;
-    concurrency?: number;
-  };
+    retry?: RetryOptions
+    rateLimit?: RateLimitOptions
+    timeout?: number
+    concurrency?: number
+  }
 }
 
 export interface StreamProgress {
-  type: 'token' | 'chunk' | 'complete';
-  tokensGenerated?: number;
-  totalTokens?: number;
-  chunk?: string;
-  estimatedTimeRemaining?: number;
+  type: 'token' | 'chunk' | 'complete'
+  tokensGenerated?: number
+  totalTokens?: number
+  chunk?: string
+  estimatedTimeRemaining?: number
 }
 
-export type ProgressCallback = (progress: StreamProgress) => void;
+export type ProgressCallback = (progress: StreamProgress) => void
 
 export interface StreamingOptions {
-  onProgress?: ProgressCallback;
-  enableTokenCounting?: boolean;
-  estimateTimeRemaining?: boolean;
+  onProgress?: ProgressCallback
+  enableTokenCounting?: boolean
+  estimateTimeRemaining?: boolean
 }
 
 export interface AIFunctionOptions {
@@ -66,8 +66,8 @@ export interface AIFunctionOptions {
   stop?: string | string[]
   seed?: number
   concurrency?: number
-  requestHandling?: RequestHandlingOptions;
-  streaming?: StreamingOptions;
+  requestHandling?: RequestHandlingOptions
+  streaming?: StreamingOptions
 }
 
 export type AIFunction<T extends z.ZodTypeAny = z.ZodTypeAny> = {
@@ -79,28 +79,28 @@ export type AIFunction<T extends z.ZodTypeAny = z.ZodTypeAny> = {
 }
 
 export type AsyncIterablePromise<T> = Promise<T> & {
-  (options?: AIFunctionOptions): Promise<T>;
-  then: Promise<T>['then'];
-  catch: Promise<T>['catch'];
-  finally: Promise<T>['finally'];
-  [Symbol.asyncIterator]: () => AsyncIterator<string>;
+  (options?: AIFunctionOptions): Promise<T>
+  then: Promise<T>['then']
+  catch: Promise<T>['catch']
+  finally: Promise<T>['finally']
+  [Symbol.asyncIterator]: () => AsyncIterator<string>
 }
 
 export type TemplateResult = {
-  (options?: AIFunctionOptions): Promise<string>;
-  then: Promise<string>['then'];
-  catch: Promise<string>['catch'];
-  finally: Promise<string>['finally'];
-  [Symbol.asyncIterator]: () => AsyncIterator<string>;
-  call: (options?: AIFunctionOptions) => Promise<string>;
+  (options?: AIFunctionOptions): Promise<string>
+  then: Promise<string>['then']
+  catch: Promise<string>['catch']
+  finally: Promise<string>['finally']
+  [Symbol.asyncIterator]: () => AsyncIterator<string>
+  call: (options?: AIFunctionOptions) => Promise<string>
 }
 
 export interface BaseTemplateFunction {
-  (strings: TemplateStringsArray, ...values: unknown[]): TemplateResult;
-  (options?: AIFunctionOptions): TemplateResult;
-  [Symbol.asyncIterator]: () => AsyncIterator<string>;
-  withOptions: (options?: AIFunctionOptions) => Promise<string>;
-  queue?: Queue;
+  (strings: TemplateStringsArray, ...values: unknown[]): TemplateResult
+  (options?: AIFunctionOptions): TemplateResult
+  [Symbol.asyncIterator]: () => AsyncIterator<string>
+  withOptions: (options?: AIFunctionOptions) => Promise<string>
+  queue?: Queue
 }
 
 export type AITemplateFunction = BaseTemplateFunction & {
@@ -117,6 +117,127 @@ export interface AI extends AITemplateFunction {
       description: z.ZodString
     }>
   >
+  // Book-related functions
+  writeBook: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      author: z.ZodString
+      genre: z.ZodString
+      audience: z.ZodString
+      content: z.ZodString
+    }>
+  >
+  developProposal: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      genre: z.ZodString
+      audience: z.ZodString
+      concept: z.ZodString
+      marketAnalysis: z.ZodString
+      competitiveAnalysis: z.ZodString
+      uniqueSellingPoints: z.ZodArray<z.ZodString>
+      outline: z.ZodString
+    }>
+  >
+  draftTableOfContents: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      genre: z.ZodString
+      chapters: z.ZodArray<
+        z.ZodObject<{
+          title: z.ZodString
+          summary: z.ZodString
+        }>
+      >
+      frontMatter: z.ZodArray<z.ZodString>
+      backMatter: z.ZodArray<z.ZodString>
+    }>
+  >
+  outlineChapter: AIFunction<
+    z.ZodObject<{
+      chapterTitle: z.ZodString
+      chapterNumber: z.ZodNumber
+      keyPoints: z.ZodArray<z.ZodString>
+      scenes: z.ZodOptional<
+        z.ZodArray<
+          z.ZodObject<{
+            title: z.ZodString
+            summary: z.ZodString
+            characters: z.ZodOptional<z.ZodArray<z.ZodString>>
+          }>
+        >
+      >
+      sections: z.ZodOptional<
+        z.ZodArray<
+          z.ZodObject<{
+            heading: z.ZodString
+            content: z.ZodString
+          }>
+        >
+      >
+    }>
+  >
+  writeSection: AIFunction<
+    z.ZodObject<{
+      sectionTitle: z.ZodString
+      chapterTitle: z.ZodString
+      keyPoints: z.ZodArray<z.ZodString>
+      tone: z.ZodString
+      content: z.ZodString
+    }>
+  >
+  reviewChapter: AIFunction<
+    z.ZodObject<{
+      chapterTitle: z.ZodString
+      content: z.ZodString
+      feedback: z.ZodString
+      strengthPoints: z.ZodArray<z.ZodString>
+      improvementPoints: z.ZodArray<z.ZodString>
+      consistencyIssues: z.ZodOptional<z.ZodArray<z.ZodString>>
+    }>
+  >
+  editChapter: AIFunction<
+    z.ZodObject<{
+      chapterTitle: z.ZodString
+      originalContent: z.ZodString
+      editedContent: z.ZodString
+      changes: z.ZodArray<z.ZodString>
+      rationale: z.ZodString
+    }>
+  >
+  reviewBook: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      content: z.ZodString
+      overallFeedback: z.ZodString
+      strengthPoints: z.ZodArray<z.ZodString>
+      improvementPoints: z.ZodArray<z.ZodString>
+      marketFit: z.ZodString
+      recommendations: z.ZodArray<z.ZodString>
+    }>
+  >
+  editBook: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      originalContent: z.ZodString
+      editedContent: z.ZodString
+      majorChanges: z.ZodArray<z.ZodString>
+      minorChanges: z.ZodArray<z.ZodString>
+      rationale: z.ZodString
+    }>
+  >
+  publishBook: AIFunction<
+    z.ZodObject<{
+      title: z.ZodString
+      author: z.ZodString
+      finalContent: z.ZodString
+      publishingPlatforms: z.ZodArray<z.ZodString>
+      marketingPlan: z.ZodString
+      launchDate: z.ZodString
+      pricingStrategy: z.ZodString
+      distributionChannels: z.ZodArray<z.ZodString>
+    }>
+  >
 }
 
 export type ListFunction = BaseTemplateFunction
@@ -125,9 +246,9 @@ export class AIRequestError extends Error {
   constructor(
     message: string,
     public readonly cause?: unknown,
-    public readonly retryable: boolean = true
+    public readonly retryable: boolean = true,
   ) {
-    super(message);
-    this.name = 'AIRequestError';
+    super(message)
+    this.name = 'AIRequestError'
   }
 }


### PR DESCRIPTION
This PR adds a new books.ts file with schema-only AI functions for book-related tasks including writeBook, developProposal, draftTableOfContents, outlineChapter, writeSection, reviewChapter, editChapter, reviewBook, editBook, and publishBook.

Link to Devin run: https://app.devin.ai/sessions/144f0283972a4b71bbaa59bc714a9a88